### PR TITLE
Speedup parsing lengths by exploiting float32 vs. uint32 structure

### DIFF
--- a/load_trk_newer.py
+++ b/load_trk_newer.py
@@ -1,0 +1,206 @@
+# Copyright (c) 2019 Pietro Astolfi, Emanuele Olivetti
+# MIT License
+
+import os
+import numpy as np
+import nibabel as nib
+from struct import unpack
+from time import time
+
+
+def get_length_struct(f, nb_bytes_int32=4, int32_fmt='<i'):
+    """Parse an int32 from a file. struct.unpack() version.
+    """
+    return unpack(int32_fmt, f.read(nb_bytes_int32))[0]
+
+
+def load_streamlines(trk_fn, idxs=None, apply_affine=True,
+                     container='list', replace=False, verbose=False):
+    """Load streamlines from a .trk file. If a list of indices (idxs) is
+    given, this function just loads and returns the requested
+    streamlines, skipping all the non-requested ones.
+
+    This function is sort of similar to nibabel.streamlines.load() but
+    extremely FASTER. It is very convenient if you need to load only
+    some streamlines in large tractograms. Like 100x faster than what
+    you can get with nibabel.
+    """
+
+    if verbose:
+        print("Loading %s" % trk_fn)
+
+    lazy_trk = nib.streamlines.load(trk_fn, lazy_load=True)
+    header = lazy_trk.header
+    header_size = header['hdr_size']
+    nb_streamlines = header['nb_streamlines']
+    n_scalars = header['nb_scalars_per_point']
+    n_properties = header['nb_properties_per_streamline']
+    aff = nib.streamlines.trk.get_affine_trackvis_to_rasmm(header)
+
+    if idxs is None:
+        idxs = np.arange(nb_streamlines, dtype=int)
+    elif isinstance(idxs, int):
+        if verbose:
+            print('Sampling %s streamlines uniformly at random' % idxs)
+
+        if idxs > nb_streamlines and (not replace):
+            print('WARNING: Sampling with replacement')
+
+        idxs = np.random.choice(np.arange(nb_streamlines), idxs,
+                                replace=replace)
+
+    ## See: http://www.trackvis.org/docs/?subsect=fileformat
+    length_bytes = 4
+    point_size = 3 + n_scalars
+    point_bytes = 4 * point_size
+    properties_bytes = n_properties * 4
+
+    nb_bytes_uint32 = np.dtype('<u4').itemsize
+    nb_bytes_float32 = np.dtype('<f').itemsize
+
+    if verbose:
+        print("Parsing lenghts of %s streamlines" % nb_streamlines)
+        t0 = time()
+
+    offsets = np.empty(nb_streamlines, dtype=int)
+    lengths = np.empty(nb_streamlines, dtype=np.int32)
+
+
+    #####
+    # Heuristic for extracting streamline lengths from a TRK file.
+    ##
+    # Leverage the fact that float32 numbers greater than ~1.4e-40
+    # when viewed as uint32 are larger than 100000.
+    # i.e., numbers < 100000 must be the 'length' values.
+    # Since float32(0) == int32(0), we may got false postives.
+    # However, we can assume that length of a streamline is greater than 0.
+    chunk_size = 256 * 1024 ** 2  # 256 Mb
+    buffer = np.empty((chunk_size // nb_bytes_uint32), np.uint32)
+    with open(trk_fn, 'rb') as f:
+        f.seek(1000)  # 1000 is the size of the header in bytes
+
+        cnt = 0
+        chunk_id = 0
+        while True:
+            nbytes_read = f.readinto(buffer)
+            if not nbytes_read:
+                break
+
+            nb_int32_read = nbytes_read // nb_bytes_uint32
+            offsets_ = np.where(np.logical_and(buffer[:nb_int32_read] < 100000, buffer[:nb_int32_read] > 0))[0]
+            offsets[cnt:cnt+len(offsets_)] = offsets_
+            offsets[cnt:cnt+len(offsets_)] *= nb_bytes_uint32
+            offsets[cnt:cnt+len(offsets_)] += chunk_id * chunk_size
+            lengths[cnt:cnt+len(offsets_)] = buffer[offsets_]
+
+            cnt += len(offsets_)
+            chunk_id += 1
+
+    lengths = np.array(lengths)
+    offsets += header_size + nb_bytes_uint32
+    index_bytes = offsets
+
+    if verbose:
+        print("%s sec." % (time() - t0))
+        t0 = time()
+
+    if len(offsets) > nb_streamlines:
+        # If we detected more 'length' values than there are streamlines,
+        # we can fallback on the more robust (but slower) method.
+        print("*Using fallback method*")
+
+        # In order to reduce the 20x increase in time when reading small
+        # amounts of bytes with NumPy and Python >3.2, we use two
+        # different implementations of the function that parses 4 bytes
+        # into an int32:
+        # if float(sys.version[:3]) > 3.2:
+        #     get_length = get_length_from_bytes
+        # else:
+        #     get_length = get_length_numpy
+
+        # The following function is OKish for all versions of Python:
+        get_length = get_length_struct
+
+        lengths = np.empty(nb_streamlines, dtype=np.int32)
+        with open(trk_fn, 'rb') as f:
+            f.seek(header_size)
+            for idx in range(nb_streamlines):
+                l = get_length(f)
+                lengths[idx] = l
+                jump = point_bytes * l + properties_bytes
+                f.seek(jump, 1)
+
+        # position in bytes where to find a given streamline in the TRK file:
+        index_bytes = lengths * point_bytes + properties_bytes + length_bytes
+        index_bytes = np.concatenate([[length_bytes], index_bytes[:-1]]).cumsum() + header_size
+
+        if verbose:
+            print("%s sec." % (time() - t0))
+
+    if verbose:
+        print("Extracting %s streamlines with the desired id" % len(idxs))
+        t0 = time()
+
+    seq = nib.streamlines.ArraySequence()
+
+    seq._data = np.empty((lengths.sum(), point_size), np.float32)
+    seq._lengths = lengths
+    seq._offsets = np.cumsum(np.pad(lengths[:-1], (1, 0), "constant"))  # Prepend 0
+
+    with open(trk_fn, 'rb') as f:
+        for idx, offset in zip(idxs, seq._offsets):
+            # move to the position initial position of the coordinates
+            # of the streamline:
+            f.seek(index_bytes[idx])
+            # Parse the floats:
+            f.readinto(seq._data[offset:offset+lengths[idx]])
+
+    if verbose:
+        print("%s sec." % (time() - t0))
+        print("Casting ArraySequence to list of ndarray")
+        t0 = time()
+
+    # Get the streamlines as a list instead of ArraySequence (to match the expected returned output).
+    streamlines = [s[:, :3] for s in seq]  # NB: This is slow.
+
+    if verbose:
+        print("%s sec." % (time() - t0))
+
+    if verbose:
+        print("Converting all streamlines to the container %s" % container)
+        t0 = time()
+
+    if container == 'array':
+        streamlines = np.array(streamlines, dtype=np.object)
+    elif container == 'ArraySequence':
+        streamlines = nib.streamlines.ArraySequence(streamlines)
+    elif container == 'list':
+        pass
+    elif container == 'array_flat':
+        streamlines = np.concatenate(streamlines, axis=0)
+    else:
+        raise Exception
+
+    if verbose:
+        print("%s sec." % (time() - t0))
+
+    return streamlines, header, lengths[idxs], idxs
+
+
+if __name__ == '__main__':
+
+    np.random.seed(0)
+
+    trk_fn = 'sub-100206_var-FNAL_tract.trk'
+    trk_fn = 'sub-599469_var-10M_tract.trk'
+
+    # idxs = np.random.choice(500000, 200000, replace=True)
+    # idxs.sort()
+    idxs = None  # This is for loading all streamlines
+    # idxs = 1000
+
+    streamlines, header, lengths, idxs = load_streamlines(trk_fn,
+                                                          idxs,
+                                                          apply_affine=True,
+                                                          container='list',
+                                                          verbose=True)

--- a/test_load_trk_numpy_save.py
+++ b/test_load_trk_numpy_save.py
@@ -1,6 +1,8 @@
 import numpy as np
 from load_trk import load_streamlines
+from load_trk_no_numba import load_streamlines as load_streamlines_no_numba
 from load_trk_new import load_streamlines as load_streamlines_new
+from load_trk_newer import load_streamlines as load_streamlines_newer
 from load_trk_numba import load_streamlines as load_streamlines_numba
 from time import time
 
@@ -22,10 +24,22 @@ if __name__=='__main__':
     print(f"Total time: {time() - t0} sec.")
 
     print("")
+    print("Using load_trk_newer.py")
+    t0 = time()
+    streamlines, header, lengths, idxs = load_streamlines_newer(filename, idxs=range(n_streamlines), apply_affine=False, container='array', verbose=True)
+    print(f"Total time: {time() - t0} sec. Checksum: {sum(s.sum() for s in streamlines)}")
+
+    print("")
+    print("Using load_trk_no_numba.py")
+    t0 = time()
+    streamlines, header, lengths, idxs = load_streamlines_no_numba(filename, idxs=range(n_streamlines), apply_affine=False, container='array', verbose=True)
+    print(f"Total time: {time() - t0} sec. Checksum: {sum(s.sum() for s in streamlines)}")
+
+    print("")
     print("Using load_trk_numba.py")
     t0 = time()
     streamlines, header, lengths, idxs = load_streamlines_numba(filename, idxs=range(n_streamlines), apply_affine=False, container='array', verbose=True)
-    print(f"Total time: {time() - t0} sec.")
+    print(f"Total time: {time() - t0} sec. Checksum: {sum(s.sum() for s in streamlines)}")
 
     print("")
     filename_npy = filename[:-4] + '_no_resample.npy'


### PR DESCRIPTION
Hi @emanuele, I believe I found a way to improve the speed for parsing the streamline lengths. It might need more testing, but I thought I would share it with you anyway.

Here are the results I get on my laptop (with SSD). The relevant parts are `load_trk_newer.py` and `load_trk_no_numba.py`. I also added a checksum to make sure the loaded streamlines are the same for all methods (`Checksum: 28226791454.458008`).
```
Using load_trk.py
Loading data/sub-599469_var-10M_tract.trk
Parsing lenghts of 10000000 streamlines
14.822022438049316 sec.
Extracting 4000000 streamlines with the desired id
78.17423558235168 sec.
Converting all streamlines to the container array
0.13917803764343262 sec.
Total time: 94.22346591949463 sec.

Using load_trk_new.py
Loading data/sub-599469_var-10M_tract.trk
Parsing lenghts of 10000000 streamlines
12.099209785461426 sec.
Extracting 4000000 streamlines with the desired id
22.72183060646057 sec.
Converting all streamlines to the container array
0.1382434368133545 sec.
Total time: 37.516242265701294 sec.

  Using load_trk_newer.py
  Loading data/sub-599469_var-10M_tract.trk
  Parsing lenghts of 10000000 streamlines
  2.5172533988952637 sec.
  Extracting 4000000 streamlines with the desired id
  7.231152772903442 sec.
  Casting ArraySequence to list of ndarray    <------ Working directly with an ArraySequence would avoid this.
  10.564280033111572 sec.
  Converting all streamlines to the container array
  0.29190659523010254 sec.
  Total time: 21.28335165977478 sec. Checksum: 28226791454.458008
  
  Using load_trk_no_numba.py
  Loading data/sub-599469_var-10M_tract.trk
  Loading the whole data blob.
  751859555 values read in 1.3201448917388916 sec.
  Parsing lengths of 10000000 streamlines
  1.38914155960083 sec.
  Extracting 4000000 streamlines
  4.8606531620025635 sec.
  Converting all streamlines to the container array
  0.11880946159362793 sec.
  Total time: 9.421625137329102 sec. Checksum: 28226791454.458008

Using load_trk_numba.py
Loading data/sub-599469_var-10M_tract.trk
Loading the whole data blob.
751859555 values read in 1.5123486518859863 sec.
Parsing lengths of 10000000 streamlines
1.3011393547058105 sec.
Extracting 4000000 streamlines
2.1483805179595947 sec.
Converting all streamlines to the container array
0.1565077304840088 sec.
Total time: 6.776575803756714 sec. Checksum: 28226791454.458008

Saving original streamlines in npz format to data/sub-599469_var-10M_tract_no_resample.npy
Total time: 49.95222306251526 sec.

Loading data/sub-599469_var-10M_tract_no_resample.npy
Total time: 37.35902452468872 sec.
```